### PR TITLE
Fixed python migration error

### DIFF
--- a/mir_planning/mir_knowledge/ros/src/mir_knowledge_ros/problem_uploader.py
+++ b/mir_planning/mir_knowledge/ros/src/mir_knowledge_ros/problem_uploader.py
@@ -88,7 +88,7 @@ class ProblemUploader(object):
 
         """
         ki_list = []
-        for instance_type, instance_names in instances.iteritems():
+        for instance_type, instance_names in instances.items():
             for instance_name in instance_names:
                 ki_list.append(
                     KnowledgeItem(


### PR DESCRIPTION
Changed line 91 from " for instance_type, instance_names in instances.iteritems() " to " for instance_type, instance_names in instances.items()" as iteritems() is discontinued in python 3.x